### PR TITLE
No longer optimizes when property values are equal.

### DIFF
--- a/src/property-interpolation.js
+++ b/src/property-interpolation.js
@@ -108,7 +108,7 @@
       if (right == 'initial')
         right = initialValues[ucProperty];
     }
-    var handlers = left == right ? [] : propertyHandlers[ucProperty];
+    var handlers = propertyHandlers[ucProperty];
     for (var i = 0; handlers && i < handlers.length; i++) {
       var parsedLeft = handlers[i][0](left);
       var parsedRight = handlers[i][0](right);


### PR DESCRIPTION
- If the value for a property in the initial keyframe is equal to the value for that same property in the final keyframe the polyfill will not parse the values for that property. 

- This becomes problematic when the value is something that the browser doesn't know how to handle, for example basic shapes. 

- The cases where the property values are equal in both the initial and final keyframes are rare enough that I believe we can do without this optimization.